### PR TITLE
ENH: Remove unnecessary `SkullStrip.remote.cmake` file.

### DIFF
--- a/SkullStrip.remote.cmake
+++ b/SkullStrip.remote.cmake
@@ -1,5 +1,0 @@
-itk_fetch_module(SkullStrip
-  "A class to perform automatic skull-stripping for neuroimage analysis."
-  GIT_REPOSITORY https://github.com/lorensen/skullStrip.git
-  GIT_TAG master
-  )


### PR DESCRIPTION
The `SkullStrip.remote.cmake` file was surely added to ease the use of the
remote module in ITK. The module exists as a remote since a long time ago
in ITK:
https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Remote/SkullStrip.remote.cmake

And thus, strictly speaking, this file is no longer necessary.

Also, deleting it will help in removing clutter from the root directory.

Finally, strictly speaking, it should not be here.