### PR TITLE
ENH: Conform `README` to `ITKModuleTemplate` convention.

### DIFF
--- a/README
+++ b/README
@@ -1,2 +1,0 @@
-testing repository for itkStripTsImageFilter
-This ITK filter performs automatic skull-stripping for neuroimage analysis.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,39 @@
+ITKSkullStripping
+=================
+
+.. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/ITKSkullStrip.svg?style=shield
+    :target: https://circleci.com/gh/InsightSoftwareConsortium/ITKSkullStrip
+
+.. |TravisCI| image:: https://travis-ci.org/InsightSoftwareConsortium/ITKSkullStrip.svg?branch=master
+    :target: https://travis-ci.org/InsightSoftwareConsortium/ITKSkullStrip
+
+.. |AppVeyor| image:: https://img.shields.io/appveyor/ci/itkrobot/itkskullstrip.svg
+    :target: https://ci.appveyor.com/project/itkrobot/itkskullstrip
+
+=========== =========== ===========
+   Linux      macOS       Windows
+=========== =========== ===========
+|CircleCI|  |TravisCI|  |AppVeyor|
+=========== =========== ===========
+
+
+Overview
+--------
+
+This is a module for the `Insight Toolkit (ITK) <http://itk.org>`_ that
+performs automatic skull-stripping for neuroimage analysis.
+
+For more information, see the `Insight Journal article <http://hdl.handle.net/10380/3353>`_::
+
+  Bauer S., Fejes T., Reyes M.
+  Skull-Stripping Filter for ITK
+  The Insight Journal. January-December. 2012.
+  http://hdl.handle.net/10380/3353
+  http://www.insight-journal.org/browse/publication/859
+
+
+License
+-------
+
+This software is distributed under the Apache 2.0 license. Please see
+the *LICENSE* file for details.


### PR DESCRIPTION
Conform the `README` file to the `ITKModuleTemplate` convention:
- Use resTructuredText syntax.
- Add the CI build badges.
- Split the file into sections.
- Cross-reference the IJ article.
- Cross-reference the `LICENSE` file.