### PR TITLE
ENH: Add CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+version: 2
+jobs:
+  build-and-test:
+    working_directory: /ITKSkullStrip-build
+    docker:
+      - image: insighttoolkit/module-ci:latest
+    steps:
+      - checkout:
+          path: /ITKSkullStrip
+      - run:
+          name: Fetch CTest driver script
+          command: |
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+      - run:
+          name: Configure CTest script
+          command: |
+            SHASNIP=$(echo $CIRCLE_SHA1 | cut -c1-7)
+            cat > dashboard.cmake << EOF
+            set(CTEST_SITE "CircleCI")
+            set(CTEST_BUILD_NAME "External-ITKSkullStrip-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
+            set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+            set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+            set(CTEST_BUILD_FLAGS: "-j5")
+            set(CTEST_SOURCE_DIRECTORY /ITKSkullStrip)
+            set(CTEST_BINARY_DIRECTORY /ITKSkullStrip-build)
+            set(dashboard_model Experimental)
+            set(dashboard_no_clean 1)
+            set(dashboard_cache "
+            ITK_DIR:PATH=/ITK-build
+            BUILD_TESTING:BOOL=ON
+            ")
+            include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+            EOF
+      - run:
+          name: Build and Test
+          no_output_timeout: 1.0h
+          command: |
+            ctest -j 2 -VV -S dashboard.cmake
+  package:
+    working_directory: ~/ITKSkullStrip
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Fetch build script
+          command: |
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
+            chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
+      - run:
+          name: Build Python packages
+          no_output_timeout: 1.0h
+          command: |
+            ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
+      - store_artifacts:
+          path: dist
+          destination: dist
+
+workflows:
+    version: 2
+    build-test-package:
+      jobs:
+        - build-and-test
+        - package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: true
+language: cpp
+os:
+- osx
+compiler:
+- gcc
+cache:
+  directories:
+  - "$HOME/Library/Caches/Homebrew"
+script:
+- curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
+- chmod u+x macpython-download-cache-and-build-module-wheels.sh
+- ./macpython-download-cache-and-build-module-wheels.sh
+- tar -zcvf dist.tar.gz dist/
+- curl --upload-file dist.tar.gz https://transfer.sh/dist.tar.gz

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,7 @@
+set(CTEST_PROJECT_NAME "ITK")
+set(CTEST_NIGHTLY_START_TIME "1:00:00 UTC")
+
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "open.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=Insight")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+branches:
+ only:
+  - master
+
+version: "0.0.1.{build}"
+
+install:
+
+  - curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/windows-download-cache-and-build-module-wheels.ps1 -O
+  - ps: .\windows-download-cache-and-build-module-wheels.ps1
+
+build: off
+
+test: off
+
+artifacts:
+
+  # pushing entire folder as a zip archive
+  - path: dist\*
+
+deploy: off

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,31 +1,37 @@
-set(DOCUMENTATION "This module contains a class to perform automatic skull-stripping for neuroimage analysis.
-It is based on the ITK level-set and registration frameworks." )
+# the top-level README is used for describing this module, just
+# re-used it for documentation here
+get_filename_component(MY_CURENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURENT_DIR}/README.rst" DOCUMENTATION)
 
-itk_module( SkullStrip
+# itk_module() defines the module dependencies in SkullStrip
+# The testing module in SkullStrip depends on ITKTestKernel
+# By convention those modules outside of ITK are not prefixed with
+# ITK
+
+# define the dependencies of the include module and the tests
+itk_module(SkullStrip
   DEPENDS
     ITKLevelSets
     ITKRegistrationCommon
     ITKIOImageBase
     ITKImageIntensity
     ITKIOMeta
-# Image IO Modules
-  ITKIOJPEG
-  ITKIOGDCM
-  ITKIOBMP
-  ITKIOLSM
-  ITKIOPNG
-  ITKIOTIFF
-  ITKIOVTK
-  ITKIOStimulate
-  ITKIOBioRad
-  ITKIOMeta
-  ITKIONIFTI
-  ITKIONRRD
-  ITKIOGIPL
-# Transform IO Modules
-  ITKIOTransformMatlab
-  ITKIOTransformHDF5
-  ITKIOTransformInsightLegacy
+    ITKIOJPEG
+    ITKIOGDCM
+    ITKIOBMP
+    ITKIOLSM
+    ITKIOPNG
+    ITKIOTIFF
+    ITKIOVTK
+    ITKIOStimulate
+    ITKIOBioRad
+    ITKIOMeta
+    ITKIONIFTI
+    ITKIONRRD
+    ITKIOGIPL
+    ITKIOTransformMatlab
+    ITKIOTransformHDF5
+    ITKIOTransformInsightLegacy
   TEST_DEPENDS
     ITKTestKernel
   EXCLUDE_FROM_DEFAULT

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from os import sys
+
+try:
+    from skbuild import setup
+except ImportError:
+    print('scikit-build is required to build from source.', file=sys.stderr)
+    print('Please run:', file=sys.stderr)
+    print('', file=sys.stderr)
+    print('  python -m pip install scikit-build')
+    sys.exit(1)
+
+setup(
+    name='itk-skullstripping',
+    version='0.0.1',
+    author='Stefan Bauer',
+    author_email='stefan.bauer@istb.unibe.ch',
+    packages=['itk'],
+    package_dir={'itk': 'itk'},
+    download_url=r'https://github.com/InsightSoftwareConsortium/ITKSkullStrip',
+    description=r'Automatic skull-stripping for neuroimage analysis',
+    long_description='ITKSkullStrip provides a class to perform automatic'
+                     'skull-stripping for neuroimage analysis.\n'
+                     'Please refer to:'
+                     'Bauer S., Fejes T., Reyes M.,'
+                     '“Skull-Stripping Filter for ITK”, '
+                     'Insight Journal, http://hdl.handle.net/10380/3353, 2012.',
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: C++",
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Healthcare Industry",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Medical Science Apps.",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Software Development :: Libraries",
+        "Operating System :: Android",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Operating System :: Unix",
+        "Operating System :: MacOS"
+        ],
+    license='Apache',
+    keywords='ITK InsightToolkit neuroimaging neuroimaging-analysis',
+    url=r'https://github.com/InsightSoftwareConsortium/ITKSkullStrip',
+    install_requires=[
+        r'itk'
+    ]
+    )

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,0 +1,3 @@
+itk_wrap_module(SkullStrip)
+itk_auto_load_submodules()
+itk_end_wrap_module()

--- a/wrapping/itkStripTsImageFilter.wrap
+++ b/wrapping/itkStripTsImageFilter.wrap
@@ -1,0 +1,3 @@
+itk_wrap_class("itk::SkullStrip" POINTER)
+  itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 2+)
+itk_end_wrap_class()


### PR DESCRIPTION
Add CI:
- Add `*.yml` configuration files for CI.
- Add Python wrapping files.
- Add the `setup.py` file for Python packaging.
- Add the `CTestConfig.cmake` file to make the build results be sent to
  the **Insight** project in **open.cdash.org**.
- Modify the `itk-module.cmake` to take advantage of the module
documentation in the `README.rst` file.