### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkStripTsImageFilter.hxx
+++ b/include/itkStripTsImageFilter.hxx
@@ -20,7 +20,6 @@
 #ifndef itkStripTsImageFilter_hxx
 #define itkStripTsImageFilter_hxx
 
-#include "itkStripTsImageFilter.h"
 #include "itkLabelImageGaussianInterpolateImageFunction.h"
 
 namespace itk


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

